### PR TITLE
Leave units on 0 time values.

### DIFF
--- a/csscompressor/__init__.py
+++ b/csscompressor/__init__.py
@@ -56,8 +56,11 @@ _space_after_re = re.compile(r'([!{}:;>+\(\[,])\s+')
 _semi_re = re.compile(r';+}')
 
 _zero_fmt_spec_re = re.compile(r'''(\s|:|\(|,)(?:0?\.)?0
-                                    (?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)''',
+                                    (?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|k?hz)''',
                                re.I | re.X)
+
+_zero_req_unit_re = re.compile(r'''(\s|:|\(|,)(?:0?\.)?0
+                                    (m?s)''', re.I | re.X)
 
 _bg_pos_re = re.compile(r'''(background-position|webkit-mask-position|transform-origin|
                                 webkit-transform-origin|moz-transform-origin|o-transform-origin|
@@ -376,6 +379,9 @@ def _compress(css, max_linelen=0):
 
     # Replace 0(px,em,%) with 0.
     css = _zero_fmt_spec_re.sub(lambda match: match.group(1) + '0', css)
+
+    # Replace 0.0(m,ms) or .0(m,ms) with 0(m,ms)
+    css = _zero_req_unit_re.sub(lambda match: match.group(1) + '0' + match.group(2), css)
 
     # Replace 0 0 0 0; with 0.
     css = _quad_0_re.sub(r':0\1', css)

--- a/csscompressor/tests/test_yui.py
+++ b/csscompressor/tests/test_yui.py
@@ -1458,7 +1458,7 @@ serve! */"""
 
         """
 
-        output = """a{margin:0;_padding-top:0;background-position:0 0;padding:0;transition:opacity 0;transition-delay:0;transform:rotate3d(0,0,0);pitch:0;pitch:0}"""
+        output = """a{margin:0;_padding-top:0;background-position:0 0;padding:0;transition:opacity 0s;transition-delay:0ms;transform:rotate3d(0,0,0);pitch:0;pitch:0}"""
 
         self._test(input, output)
 


### PR DESCRIPTION
Fixes #3.

Removing the `m?s` from `_zero_req_unit_re` would've been enough to leave the units on the value, but it would've left `0.0` and `.0` uncompressed, so I created a new RE to handle that.

In terms of maintaining compatibility with YUI, I'm planning to do a similar PR against that, too. There's already a PR to fix this issue, but it's been abandoned because of lack of tests; that PR also doesn't handle `0.0` and `.0` (it just removes the `m?s`).
